### PR TITLE
Fix index issues in scoring

### DIFF
--- a/text_lloom/src/text_lloom/concept_induction.py
+++ b/text_lloom/src/text_lloom/concept_induction.py
@@ -794,7 +794,7 @@ async def score_concepts(text_df, text_col, doc_id_col, concepts, model_name="gp
     score_dfs = await tqdm_asyncio.gather(*tasks, file=sys.stdout)
 
     # Combine score_dfs
-    score_df = pd.concat(score_dfs)
+    score_df = pd.concat(score_dfs, ignore_index=True)
 
     save_progress(sess, score_df, step_name="Score", start=start, res=None, model_name=None)
     return score_df


### PR DESCRIPTION
When concatenating dataframes, the index is preserved. In the case of concatenating scores into dataframes, it is better to ignore_index since all the incoming dataframes have the same index. This causes a lot of issues, when doing more analysis using the score_df. 