### PR TITLE
adding the concepts dict as a possible output for the synthesize module

### DIFF
--- a/text_lloom/src/text_lloom/concept_induction.py
+++ b/text_lloom/src/text_lloom/concept_induction.py
@@ -299,7 +299,7 @@ def dict_to_json(examples):
 # Output: 
 # - concepts: dict (concept_id -> concept dict)
 # - concept_df: DataFrame (columns: doc_id, doc, concept_id, concept_name, concept_prompt)
-async def synthesize(cluster_df, doc_col, doc_id_col, model, cluster_id_col="cluster_id", concept_col_prefix="concept", n_concepts=None, batch_size=None, verbose=False, pattern_phrase="unifying pattern", dedupe=True, prompt_template=None, seed=None, sess=None, return_logs=False):
+async def synthesize(cluster_df, doc_col, doc_id_col, model, cluster_id_col="cluster_id", concept_col_prefix="concept", n_concepts=None, batch_size=None, verbose=False, pattern_phrase="unifying pattern", dedupe=True, prompt_template=None, seed=None, sess=None, return_logs=False, return_concepts_dict=False):
     # Synthesis operates on "doc" column for each cluster_id
     # Concept object is created for each concept
     start = time.time()
@@ -408,9 +408,14 @@ async def synthesize(cluster_df, doc_col, doc_id_col, model, cluster_id_col="clu
         for c_id, c in concepts.items():
             sess.concepts[c_id] = c
     
-    if return_logs:
-        return concept_df, logs
-    return concept_df
+
+    if return_concepts_dict:
+        return concepts, concept_df, logs
+    else:
+        if return_logs:
+            return concept_df, logs
+        else:
+            return concept_df
 
 def dedupe_concepts(df, concept_col):
     # Remove duplicate concept rows


### PR DESCRIPTION
This pull request adds a new optional parameter `return_concepts_dict` to the `synthesize()` function in the `concept_induction.py` module. When set to _True_, the function will return the concepts dictionary along with the concept DataFrame and logs.

The motivation for this change is to provide more flexibility in how the output of the concept synthesis process is returned, specially when working with the low-level LLooM APIs. In some cases, it may be more convenient to work with the concepts objets dict form rather than a DataFrame.

### Changes

- Added a new parameter `return_concepts_dict` to the `synthesize()` function signature
- Updated the function to return the concepts dictionary if `return_concepts_dict` is set to True

### Notes
- This does not affect the Workbench API, only provides more flexibility when working direct with the Low Level API Operators. 
